### PR TITLE
fix: selectタグでoptionのvaluesが未知の場合の処理

### DIFF
--- a/src/handlers/chrome-handlers.ts
+++ b/src/handlers/chrome-handlers.ts
@@ -66,11 +66,18 @@ export const selectHandler: ActionHandler<"select"> = async (
   { action }
 ) => {
   const select = action.form;
-  const v = select.constrains.values;
-  await ctx.select(
-    select.selector,
-    `${v[Math.floor(Math.random() * v.length)]}`
-  );
+  const v = select.constrains && select.constrains.values;
+  if (v && v.length > 0) {
+    await ctx.select(
+      select.selector,
+      `${v[Math.floor(Math.random() * v.length)]}`
+    );
+    return;
+  }
+  const value = await ctx.evaluate(selector => {
+    return document.querySelector(selector).children[1].value;
+  }, select.selector);
+  await ctx.select(select.selector, `${value}`);
 };
 
 export const ensureHandler: ActionHandler<"ensure"> = async (

--- a/src/handlers/ie-handlers.ts
+++ b/src/handlers/ie-handlers.ts
@@ -64,8 +64,21 @@ export const clickHandler: ActionHandler<"click"> = async (
 
 export async function selectHandler(driver, { action }) {
   const select = action.form;
-  const v = select.constrains.values;
-  const value = v[Math.floor(Math.random() * v.length)];
+  const v = select.constrains && select.constrains.values;
+  let value = "";
+  if (v && v.length > 0) {
+    value = v[Math.floor(Math.random() * v.length)];
+  } else {
+    /* tslint:disable only-arrow-functions */
+    const selectValueFunction = function(parentSelector) {
+      return document.querySelector(parentSelector).children[0].value;
+    };
+    /* tslint:enable */
+    value = await driver.executeScript(
+      selectValueFunction,
+      action.form.selector
+    );
+  }
   const selector = `${select.selector} [value='${value}']`;
   await driver.findElement(By.css(selector)).click();
 }


### PR DESCRIPTION
`type: select` で、optionのvaluesがyamlを書いている段階で不明である場合の処理として、1つ目のvalueを選ぶようにしてみましたが、何か他にスマートな解決策があれば...って感じです。